### PR TITLE
Fixed CSV export when custom query is used.

### DIFF
--- a/app/patches/controllers/issues_controller_patch.rb
+++ b/app/patches/controllers/issues_controller_patch.rb
@@ -17,7 +17,7 @@ module DefaultCustomQuery
       case
       when params[:query_id].present?
         # Nothing to do
-      when api_request?
+      when api_request? || csv_request?
         # Nothing to do
       when show_all_issues?
         params[:set_filter] = 1
@@ -80,6 +80,10 @@ module DefaultCustomQuery
       IssueQuery.only_public
                 .where('project_id is null or project_id = ?', @project.id)
                 .where(id: query_id).exists?
+    end
+
+    def csv_request?
+      params[:format] == 'csv'
     end
   end
 end


### PR DESCRIPTION
When you have a default query set up on a project, the CSV export will use it when a temporary (session) query is created.

Steps to reproduce:
1. Go to a project and set a default query that returns no data.
2. Create a temporary query that displays some issues.
3. Press CSV export.
4. Notice no issues are displayed in the export files.

If you consider the method to be overkill I can inline it.
