### PR TITLE
Support Redmine 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,18 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
 
 env:
-  - REDMINE_REPOS=branches/3.4-stable
-  - REDMINE_REPOS=branches/3.3-stable
-  - REDMINE_REPOS=branches/3.2-stable
-  - REDMINE_REPOS=branches/3.1-stable
-
-gemfile:
-  - $REDMINE_PATH/Gemfile
-
-matrix:
-  allow_failures:
-    - rvm: 2.4
+  - REDMINE_REPOS=branches/4.0-stable
 
 before_install:
   - export PLUGIN_NAME=redmine_default_custom_query
   - export DB=sqlite
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - export REDMINE_PATH=$HOME/redmine
+  - export BUNDLE_GEMFILE=$REDMINE_PATH/Gemfile
   - svn co http://svn.redmine.org/redmine/$REDMINE_REPOS $REDMINE_PATH
   - ln -s $TRAVIS_BUILD_DIR $REDMINE_PATH/plugins/$PLUGIN_NAME
   - cp test/database.travis.yml $REDMINE_PATH/config/database.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0
+
+- Support only Redmine 4.0 (@marius-balteanu). For older Redmine versions, please use version 1.3.0.
+- Support Ruby 2.5 and 2.6 (@marius-balteanu)
+
 ## 1.3.0
 
 - Support Redmine 3.4 (@maeda-m, @pboese)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 group :test do
   gem 'factory_girl'
+  gem 'rails-controller-testing'
 end

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Redmine plugin for setting the default custom query of Issues for each project.
 
 ## Supported versions
 
-  * Redmine 3.1, 3.2, 3.3, 3.4
-  * Ruby 2.2, 2.3, 2.4
+  * Redmine 4.0
+  * Ruby 2.2, 2.3, 2.4, 2.5, 2.6
 
 ## Install
 

--- a/app/controllers/default_custom_query_setting_controller.rb
+++ b/app/controllers/default_custom_query_setting_controller.rb
@@ -1,8 +1,7 @@
 class DefaultCustomQuerySettingController < ApplicationController
-  unloadable
 
-  before_filter :find_project_by_project_id
-  before_filter :authorize
+  before_action :find_project_by_project_id
+  before_action :authorize
 
   def update
     settings = params[:settings]

--- a/app/models/projects_default_query.rb
+++ b/app/models/projects_default_query.rb
@@ -1,5 +1,4 @@
 class ProjectsDefaultQuery < ActiveRecord::Base
-  unloadable
 
   belongs_to :project
   belongs_to :query, class_name: 'IssueQuery'

--- a/app/patches/controllers/issues_controller_patch.rb
+++ b/app/patches/controllers/issues_controller_patch.rb
@@ -2,15 +2,13 @@ require_dependency 'issues_controller'
 
 module DefaultCustomQuery
   module IssuesControllerPatch
-    unloadable
-
     extend ActiveSupport::Concern
 
     included do
-      unloadable
+      before_action :with_default_query, only: [:index], if: :default_query_module_enabled?
 
-      before_filter :with_default_query, only: [:index], if: :default_query_module_enabled?
-      alias_method_chain :retrieve_query_from_session, :default_custom_query
+      alias_method :retrieve_query_from_session_without_default_custom_query, :retrieve_query_from_session
+      alias_method :retrieve_query_from_session, :retrieve_query_from_session_with_default_custom_query
     end
 
     def with_default_query

--- a/app/patches/helpers/projects_helper_patch.rb
+++ b/app/patches/helpers/projects_helper_patch.rb
@@ -5,8 +5,8 @@ module DefaultCustomQuery
     extend ActiveSupport::Concern
 
     included do
-      unloadable
-      alias_method_chain :project_settings_tabs, :default_query_setting_tab
+      alias_method :project_settings_tabs_without_default_query_setting_tab, :project_settings_tabs
+      alias_method :project_settings_tabs, :project_settings_tabs_with_default_query_setting_tab
     end
 
     def project_settings_tabs_with_default_query_setting_tab

--- a/app/patches/models/issue_query_patch.rb
+++ b/app/patches/models/issue_query_patch.rb
@@ -5,8 +5,6 @@ module DefaultCustomQuery
     extend ActiveSupport::Concern
 
     included do
-      unloadable
-
       has_many :projects_default_queries, dependent: :nullify, foreign_key: :query_id
     end
 

--- a/app/patches/models/project_patch.rb
+++ b/app/patches/models/project_patch.rb
@@ -2,13 +2,10 @@ require_dependency 'project'
 
 module DefaultCustomQuery
   module ProjectPatch
-    unloadable
 
     extend ActiveSupport::Concern
 
     included do
-      unloadable
-
       has_many :default_queries, dependent: :delete_all, class_name: 'ProjectsDefaultQuery'
     end
 

--- a/app/patches/models/query_patch.rb
+++ b/app/patches/models/query_patch.rb
@@ -5,8 +5,6 @@ module DefaultCustomQuery
     extend ActiveSupport::Concern
 
     included do
-      unloadable
-
       scope :only_public, -> { where(visibility: Query::VISIBILITY_PUBLIC) }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
 RedmineApp::Application.routes.draw do
-  controller :default_custom_query_setting, as: 'default_custom_query_setting' do
-    put ':project_id/default_custom_query/update', action: 'update', as: 'update'
-  end
+  put ':project_id/default_custom_query/update', :controller => 'default_custom_query_setting', action: 'update', as: 'default_custom_query_setting_update'
 end

--- a/db/migrate/001_create_projects_default_queries.rb
+++ b/db/migrate/001_create_projects_default_queries.rb
@@ -1,4 +1,4 @@
-class CreateProjectsDefaultQueries < ActiveRecord::Migration
+class CreateProjectsDefaultQueries < ActiveRecord::Migration[4.2]
   def change
     create_table :projects_default_queries do |t|
       t.belongs_to :project

--- a/init.rb
+++ b/init.rb
@@ -2,8 +2,8 @@ Redmine::Plugin.register :redmine_default_custom_query do
   name 'Redmine Default Custom Query'
   author 'Katsuya Hidaka'
   description 'Redmine plugin for setting default custom query of Issues for each project'
-  version '1.3.0'
-  requires_redmine '3.1'
+  version '1.4.0'
+  requires_redmine '4.0'
   url 'https://github.com/hidakatsuya/redmine_default_custom_query'
   author_url 'https://twitter.com/hidakatsuya'
 

--- a/test/integration/manage_default_query_test.rb
+++ b/test/integration/manage_default_query_test.rb
@@ -50,8 +50,10 @@ class ManageDefaultQueryTest < Redmine::IntegrationTest
 
     # New setting
     assert_difference -> { @project.default_queries.count }, 1 do
-      xhr :put, default_custom_query_setting_update_path(@project),
-                settings: { query_id: @queries.first.id }
+      put default_custom_query_setting_update_path(@project), params: {
+                settings: { query_id: @queries.first.id },
+                xhr: true
+              }
     end
 
     assert_equal @project.default_query, @queries.first
@@ -60,8 +62,10 @@ class ManageDefaultQueryTest < Redmine::IntegrationTest
 
     # Update
     assert_no_difference -> { @project.default_queries.count } do
-      xhr :put, default_custom_query_setting_update_path(@project),
-                settings: { query_id: @queries.last.id }
+      put default_custom_query_setting_update_path(@project), params: {
+                settings: { query_id: @queries.last.id },
+                xhr: true
+              }
     end
 
     assert_equal @project.default_query, @queries.last
@@ -70,8 +74,10 @@ class ManageDefaultQueryTest < Redmine::IntegrationTest
 
     # Clear
     assert_no_difference -> { @project.default_queries.count } do
-      xhr :put, default_custom_query_setting_update_path(@project),
-                settings: { query_id: '' }
+      put default_custom_query_setting_update_path(@project), params: {
+                settings: { query_id: '' },
+                xhr: true
+                }
     end
 
     assert_nil @project.default_query
@@ -79,8 +85,10 @@ class ManageDefaultQueryTest < Redmine::IntegrationTest
     assert_template partial: 'default_custom_query_setting/_form'
 
     # Update to unselectable query
-    xhr :put, default_custom_query_setting_update_path(@project),
-              settings: { query_id: @unselectable_queries.first.id }
+    put default_custom_query_setting_update_path(@project), params: {
+              settings: { query_id: @unselectable_queries.first.id },
+              xhr: true
+            }
 
     assert_response :success
     assert_template partial: 'default_custom_query_setting/_form'


### PR DESCRIPTION
Fixes: #38

Other changes:
- Drop unmaintained Redmine versions (3.2 and 3.1)
- Run tests against Ruby 2.5 and Ruby 2.6