### PR TITLE
Global default query

### DIFF
--- a/app/controllers/default_custom_query_setting_controller.rb
+++ b/app/controllers/default_custom_query_setting_controller.rb
@@ -1,7 +1,25 @@
 class DefaultCustomQuerySettingController < ApplicationController
 
-  before_action :find_project_by_project_id
-  before_action :authorize
+  before_action :find_project_by_project_id, only: :update
+  before_action :authorize, only: :update
+  before_action :require_admin, only: [:index, :global_update]
+  
+  def index
+    @current_global_query = ProjectsDefaultQuery.get_global_query()
+  end
+
+  def global_update
+    settings = params[:settings]
+
+    @global_default_query = ProjectsDefaultQuery.get_global_query()
+    @global_default_query.query_id = settings[:query_id]
+
+    if @global_default_query.save
+      session[:query] = nil
+    else
+      logger.info @global_default_query.errors.full_messages
+    end
+  end
 
   def update
     settings = params[:settings]

--- a/app/helpers/default_custom_query_helper.rb
+++ b/app/helpers/default_custom_query_helper.rb
@@ -16,4 +16,17 @@ module DefaultCustomQueryHelper
       [group, options.collect {|o| [o.name, o.id] }]
     end
   end
+  
+  def options_for_global_queries()
+    options_groups = []
+
+    queries = IssueQuery.only_public.where(project_id: nil)
+    if queries.any?
+      options_groups << [l('default_custom_query.label_queries_for_all_projects'), queries]
+    end
+
+    options_groups.map do |group, options|
+      [group, options.collect {|o| [o.name, o.id] }]
+    end
+  end
 end

--- a/app/models/projects_default_query.rb
+++ b/app/models/projects_default_query.rb
@@ -26,6 +26,16 @@ class ProjectsDefaultQuery < ActiveRecord::Base
     super
   end
 
+  def self.get_global_query()
+    current_global_query = where(project_id: -1).first
+    
+    unless current_global_query
+      current_global_query = self.new
+      current_global_query.project_id = -1
+    end
+    current_global_query
+  end
+
   private
 
   def query_must_be_selectable

--- a/app/patches/controllers/issues_controller_patch.rb
+++ b/app/patches/controllers/issues_controller_patch.rb
@@ -62,9 +62,6 @@ module DefaultCustomQuery
 
     def apply_global_query!
       global_query = ProjectsDefaultQuery.get_global_query()
-      logger.info global_query
-      logger.info global_query.id
-      logger.info global_query.query_id
       if global_query
         params[:query_id] = global_query.query_id
       end

--- a/app/patches/controllers/issues_controller_patch.rb
+++ b/app/patches/controllers/issues_controller_patch.rb
@@ -51,12 +51,26 @@ module DefaultCustomQuery
       @project.default_query
     end
 
+    # 여기에 global query가 적용되도록 바꿔야함!
     def apply_default_query!
       default_query = find_default_query
       if default_query
         params[:query_id] = default_query.id
+      else
+        apply_global_query!
       end
     end
+
+    def apply_global_query!
+      global_query = ProjectsDefaultQuery.get_global_query()
+      logger.info global_query
+      logger.info global_query.id
+      logger.info global_query.query_id
+      if global_query
+        params[:query_id] = global_query.query_id
+      end
+    end
+
 
     def filter_applied?
       params[:set_filter]

--- a/app/patches/controllers/issues_controller_patch.rb
+++ b/app/patches/controllers/issues_controller_patch.rb
@@ -50,8 +50,7 @@ module DefaultCustomQuery
     def find_default_query
       @project.default_query
     end
-
-    # 여기에 global query가 적용되도록 바꿔야함!
+    
     def apply_default_query!
       default_query = find_default_query
       if default_query

--- a/app/views/default_custom_query_setting/index.html.erb
+++ b/app/views/default_custom_query_setting/index.html.erb
@@ -1,0 +1,19 @@
+<%= labelled_form_for @current_global_query,
+                      as: :settings,
+                      url: global_default_custom_query_setting_update_path(),
+                      remote: true, method: :put, html: { id: 'default-query-setting' } do |f| %>
+
+  <div class="box tabular">
+    <p>
+      <%= f.select :query_id, options_for_global_queries(), include_blank: true %><br>
+      <em><%=l 'default_custom_query.text_allowed_queries' %></em>
+    </p>
+  </div>
+  <%= submit_tag l(:button_save) %>
+<% end %>
+
+<script>
+  $('#default-query-setting').on('ajax:success', function(data, result, xhr) {
+    $('#tab-content-default_custom_query').html(result);
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 RedmineApp::Application.routes.draw do
+  get 'default_custom_query_setting/index', to: 'default_custom_query_setting#index'
+  put 'default_custom_query/update', :controller => 'default_custom_query_setting', action: 'global_update', as: 'global_default_custom_query_setting_update'
   put ':project_id/default_custom_query/update', :controller => 'default_custom_query_setting', action: 'update', as: 'default_custom_query_setting_update'
 end

--- a/init.rb
+++ b/init.rb
@@ -9,7 +9,10 @@ Redmine::Plugin.register :redmine_default_custom_query do
 
   project_module :default_custom_query do
     permission :manage_default_query, { default_custom_query_setting: [ :update ] }, require: :member
+    permission :manage_global_default_query, { default_custom_query_setting: [ :index ] }, require: :admin
   end
+  
+  menu :admin_menu, :default_global_custom_query, { controller: 'default_custom_query_setting', action: 'index' }, caption: 'Default Custom Query'
 end
 
 require_relative 'lib/default_custom_query'


### PR DESCRIPTION
I have implemented global default query functionality of my own, thought it would be nice to share the work.

This pull request will create an extra item in admin settings menu for default custom query which allows you to set a global default custom query.
Once it is set, global default query will be called when redmine is looking for project default query, but cannot find one.
